### PR TITLE
싱글톤 컨테이너

### DIFF
--- a/src/main/java/com/springcore/AppConfig.java
+++ b/src/main/java/com/springcore/AppConfig.java
@@ -17,16 +17,19 @@ public class AppConfig {
 
     @Bean
     public MemberService memberService() {
+        System.out.println("call AppConfig.memberService");
         return new MemberServiceImpl(memberRepository());
     }
 
     @Bean
     public MemberRepository memberRepository() {
+        System.out.println("call AppConfig.memberRepository");
         return new MemoryMemberRepository();
     }
 
     @Bean
     public OrderService orderService() {
+        System.out.println("call AppConfig.orderService");
         return new OrderServiceImpl(memberRepository(), discountPolicy());
     }
 

--- a/src/main/java/com/springcore/member/MemberServiceImpl.java
+++ b/src/main/java/com/springcore/member/MemberServiceImpl.java
@@ -18,4 +18,9 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findById(memberId);
     }
 
+    //테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
+
 }

--- a/src/main/java/com/springcore/order/OrderServiceImpl.java
+++ b/src/main/java/com/springcore/order/OrderServiceImpl.java
@@ -22,4 +22,9 @@ public class OrderServiceImpl implements OrderService {
         return new Order(memberId, itemName, itemPrice, discountPrice);
     }
 
+    //테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
+
 }

--- a/src/test/java/com/springcore/singleton/ConfigurationSingletonTest.java
+++ b/src/test/java/com/springcore/singleton/ConfigurationSingletonTest.java
@@ -1,0 +1,33 @@
+package com.springcore.singleton;
+
+import com.springcore.AppConfig;
+import com.springcore.member.MemberRepository;
+import com.springcore.member.MemberServiceImpl;
+import com.springcore.order.OrderServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationSingletonTest {
+
+    @Test
+    void configurationTest() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        MemberServiceImpl memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        OrderServiceImpl orderService = ac.getBean("orderService", OrderServiceImpl.class);
+        MemberRepository memberRepository = ac.getBean("memberRepository", MemberRepository.class);
+
+        //모두 같은 인스턴스를 참고하고 있다.
+        System.out.println("memberService -> memberRepository = " + memberService.getMemberRepository());
+        System.out.println("orderService -> memberRepository = " + orderService.getMemberRepository());
+        System.out.println("memberRepository = " + memberRepository);
+
+        //모두 같은 인스턴스를 참고하고 있다.
+        assertThat(memberService.getMemberRepository()).isSameAs(memberRepository);
+        assertThat(orderService.getMemberRepository()).isSameAs(memberRepository);
+    }
+
+}

--- a/src/test/java/com/springcore/singleton/ConfigurationSingletonTest.java
+++ b/src/test/java/com/springcore/singleton/ConfigurationSingletonTest.java
@@ -30,4 +30,14 @@ public class ConfigurationSingletonTest {
         assertThat(orderService.getMemberRepository()).isSameAs(memberRepository);
     }
 
+    @Test
+    void configurationDeep() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        //AppConfig도 스프링 빈으로 등록된다.
+        AppConfig bean = ac.getBean(AppConfig.class);
+
+        System.out.println("bean = " + bean.getClass());
+    }
+
 }

--- a/src/test/java/com/springcore/singleton/SingletonService.java
+++ b/src/test/java/com/springcore/singleton/SingletonService.java
@@ -1,0 +1,46 @@
+package com.springcore.singleton;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonService {
+
+//    1. static 영역에 객체를 딱 1개만 생성해둔다.
+    private static final SingletonService instance = new SingletonService();
+
+//    2. public으로 열어서 객체 인스터스가 필요하면 이 static 메서드를 통해서만 조회하도록 허용한다.
+    public static SingletonService getInstance() {
+        return instance;
+    }
+
+//    3. 생성자를 private으로 선언해서 외부에서 new 키워드를 사용한 객체 생성을 못하게 막는다.
+    private SingletonService() {
+    }
+
+    public void logic() {
+        System.out.println("싱글톤 객체 로직 호출");
+    }
+
+    @Test
+    @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+    public void singletonServiceTest() {
+//        private으로 생성자를 막아두었다. 컴파일 오류가 발생한다.
+//        new SingletonService();
+
+//        1. 조회: 호출할 때 마다 같은 객체를 반환
+        SingletonService singletonService1 = SingletonService.getInstance();
+//        2. 조회: 호출할 때 마다 같은 객체를 반환
+        SingletonService singletonService2 = SingletonService.getInstance();
+
+//        참조값이 같은 것을 확인
+        System.out.println("singletonService1 = " + singletonService1);
+        System.out.println("singletonService2 = " + singletonService2);
+
+//         singletonService1 == singletonService2
+        assertThat(singletonService1).isSameAs(singletonService2);
+        singletonService1.logic();
+    }
+
+}

--- a/src/test/java/com/springcore/singleton/SingletonService.java
+++ b/src/test/java/com/springcore/singleton/SingletonService.java
@@ -1,7 +1,11 @@
 package com.springcore.singleton;
 
+import com.springcore.AppConfig;
+import com.springcore.member.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +30,7 @@ public class SingletonService {
     @Test
     @DisplayName("싱글톤 패턴을 적용한 객체 사용")
     public void singletonServiceTest() {
+
 //        private으로 생성자를 막아두었다. 컴파일 오류가 발생한다.
 //        new SingletonService();
 
@@ -41,6 +46,25 @@ public class SingletonService {
 //         singletonService1 == singletonService2
         assertThat(singletonService1).isSameAs(singletonService2);
         singletonService1.logic();
+    }
+
+    @Test
+    @DisplayName("스프링 컨테이너와 싱글톤")
+    void springContainer() {
+
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+//        1. 조회: 호출할 때 마다 같은 객체를 반환
+        MemberService memberService1 = ac.getBean("memberService", MemberService.class);
+//        2. 조회: 호출할 때 마다 같은 객체를 반환
+        MemberService memberService2 = ac.getBean("memberService", MemberService.class);
+
+//        참조값이 같은 것을 확인
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+//        memberService1 == memberService2
+        assertThat(memberService1).isSameAs(memberService2);
     }
 
 }

--- a/src/test/java/com/springcore/singleton/SingletonTest.java
+++ b/src/test/java/com/springcore/singleton/SingletonTest.java
@@ -1,0 +1,27 @@
+package com.springcore.singleton;
+
+import com.springcore.AppConfig;
+import com.springcore.member.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @Test
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    void pureContainer() {
+        AppConfig appConfig = new AppConfig();
+        //1. 조회: 호출할 때 마다 객체를 생성
+        MemberService memberService1 = appConfig.memberService();
+        //2. 조회: 호출할 때 마다 객체를 생성
+        MemberService memberService2 = appConfig.memberService();
+        //참조값이 다른 것을 확인
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+        //memberService1 != memberService2
+        assertThat(memberService1).isNotSameAs(memberService2);
+    }
+
+}

--- a/src/test/java/com/springcore/singleton/StatefulService.java
+++ b/src/test/java/com/springcore/singleton/StatefulService.java
@@ -1,0 +1,16 @@
+package com.springcore.singleton;
+
+public class StatefulService {
+
+    private int price; // 상태를 유지하는 필드
+
+    public void order(String name, int price) {
+        System.out.println("name = " + name + " price = " + price);
+        this.price = price; //여기가 문제!
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+}

--- a/src/test/java/com/springcore/singleton/StatefulServiceTest.java
+++ b/src/test/java/com/springcore/singleton/StatefulServiceTest.java
@@ -1,0 +1,37 @@
+package com.springcore.singleton;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+public class StatefulServiceTest {
+
+    @Test
+    void statefulServiceSingleton() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+        StatefulService statefulService1 = ac.getBean("statefulService", StatefulService.class);
+        StatefulService statefulService2 = ac.getBean("statefulService", StatefulService.class);
+
+        //ThreadA: A사용자 10000원 주문
+        statefulService1.order("userA", 10000);
+        //ThreadB: B사용자 20000원 주문
+        statefulService2.order("userB", 20000);
+        //ThreadA: A사용자 주문 금액 조회
+        int price = statefulService1.getPrice();
+
+        //ThreadA: A사용자는 10000원을 기대했지만, 기대와 다르게 20000원 출력
+        System.out.println("price = " + price);
+        Assertions.assertThat(statefulService1.getPrice()).isEqualTo(20000);
+    }
+
+    static class TestConfig {
+        @Bean
+        public StatefulService statefulService() {
+            return new StatefulService();
+        }
+    }
+
+}


### PR DESCRIPTION
## 웹 애프리케이션과 싱글톤

- 스프링은 태생이 기업용 온라인 서비스 기술을 지원하기 위해 탄생했다.
- 대부분의 스프링 애플리케이션은 웹 애플리케이션이다. 물론 웹이 아닌 애플리케이션 개발도 얼마든지 개발할 수 있다.
-  애플리케이션은 보통 여러 고객이 동시에 요청을 한다

![a](https://user-images.githubusercontent.com/63000763/95010638-de8a4800-0665-11eb-8ba0-14a089e78a60.PNG)

- 우리가 만들었던 스프링 없는 순수한 DI 컨테이너인 AppConfig는 요청을 할 때 마다 객체를 새로 생성한다.
- 고객 트래픽이 초당 100이 나오면 초당 100개 객체가 생성되고 소멸된다! -> 메모리 낭비가 심하다.
- 해결방안은 해당 객체가 딱 1개만 생성되고, 공유하도록 설계하면 된다. -> 싱글톤 패턴

## 싱글톤 패턴

- 클래스의 인스턴스가 딱 1개만 생성되는 것을 보장하는 디자인 패턴이다.
- 그래서 객체 인스턴스를 2개 이상 생성하지 못하도록 막아야 한다.
    - private 생성자를 사용해서 외부에서 임의로 new 키워드를 사용하지 못하도록 막아야 한다

```java
public class SingletonService {

//    1. static 영역에 객체를 딱 1개만 생성해둔다.
    private static final SingletonService instance = new SingletonService();

//    2. public으로 열어서 객체 인스터스가 필요하면 이 static 메서드를 통해서만 조회하도록 허용한다.
    public static SingletonService getInstance() {
        return instance;
    }

//    3. 생성자를 private으로 선언해서 외부에서 new 키워드를 사용한 객체 생성을 못하게 막는다.
    private SingletonService() {
    }

    public void logic() {
        System.out.println("싱글톤 객체 로직 호출");
    }

}
```

> 1. static 영역에 객체 instance를 미리 하나 생성해서 올려둔다
> 2. 이 객체 인스턴스가 필요하면 오직 getInstance() 메서드를 통해서만 조회할 수 있다. 이 메서드를 호출하면 항상 같은 인스턴스를 반환한다.
> 3. 딱 1개의 객체 인스턴스만 존재해야 하므로, 생성자를 private으로 막아서 혹시라도 외부에서 new 키워드로 객체 인스턴스가 생성되는 것을 막는다.

- private으로 new 키워드를 막아두었다
- 호출할 때 마다 같은 객체 인스턴스를 반환하는 것을 확인할 수 있다

**싱글톤 패턴 문제점**
- 싱글톤 패턴을 구현하는 코드 자체가 많이 들어간다.
- 의존관계상 클라이언트가 구체 클래스에 의존한다. -> DIP를 위반한다.
- 클라이언트가 구체 클래스에 의존해서 OCP 원칙을 위반할 가능성이 높다.
- 테스트하기 어렵다.
- 내부 속성을 변경하거나 초기화 하기 어렵다.
- private 생성자로 자식 클래스를 만들기 어렵다.
- 결론적으로 유연성이 떨어진다.
- 안티패턴으로 불리기도 한다.

## 싱글톤 컨테이너

- 스프링 컨테이너는 싱글턴 패턴을 적용하지 않아도, 객체 인스턴스를 싱글톤으로 관리한다.
    - 이전에 설명한 컨테이너 생성 과정을 자세히 보자. 컨테이너는 객체를 하나만 생성해서 관리한다
- 스프링 컨테이너는 싱글톤 컨테이너 역할을 한다. 이렇게 싱글톤 객체를 생성하고 관리하는 기능을 싱글톤 레지스트리라 한다.
- 스프링 컨테이너의 이런 기능 덕분에 싱글턴 패턴의 모든 단점을 해결하면서 객체를 싱글톤으로 유지할 수 있다.
- 싱글톤 패턴을 위한 지저분한 코드가 들어가지 않아도 된다.
- DIP, OCP, 테스트, private 생성자로 부터 자유롭게 싱글톤을 사용할 수 있다.

**싱글톤 컨테이너 적용 후**

![b](https://user-images.githubusercontent.com/63000763/95010750-d1ba2400-0666-11eb-8705-79e6fbfb88e2.PNG)

- 스프링 컨테이너 덕분에 고객의 요청이 올 때 마다 객체를 생성하는 것이 아니라, 이미 만들어진 객체를 공유해서 효율적으로 재사용 사용할 수 있다.

> 참고: 스프링의 기본 빈 등록 방식은 싱글톤이지만, 싱글톤 방식만 지원하는 것은 아니다. 요청할 때 마다 새로운 객체를 생성해서 반환하는 기능도 제공한다. 자세한 내용은 뒤에 빈 스코프에서 설명하겠다.

## 싱글톤 방식의 주의점

- 싱글톤 패턴이든, 스프링 같은 싱글톤 컨테이너를 사용하든, 객체 인스턴스를 하나만 생성해서 공유하는 싱글톤 방식은 여러 클라이언트가 하나의 같은 객체 인스턴스를 공유하기 때문에 싱글톤 객체는 상태를 유지(stateful)하게 설계하면 안된다.
- 무상태(stateless)로 설계해야 한다!
    - 특정 클라이언트에 의존적인 필드가 있으면 안된다.
    - 특정 클라이언트가 값을 변경할 수 있는 필드가 있으면 안된다!
    - 가급적 읽기만 가능해야 한다.
    - 필드 대신에 자바에서 공유되지 않는, 지역변수, 파라미터, ThreadLocal 등을 사용해야 한다.
- 스프링 빈의 필드에 공유 값을 설정하면 정말 큰 장애가 발생할 수 있다!!!

**상태를 유지할 경우 발생하는 문제점 예시**
```java
public class StatefulService {

    private int price; // 상태를 유지하는 필드

    public void order(String name, int price) {
        System.out.println("name = " + name + " price = " + price);
        this.price = price; //여기가 문제!
    }

    public int getPrice() {
        return price;
    }

}
```

**상태를 유지할 경우 발생하는 문제점 예시**
```java
public class StatefulServiceTest {

    @Test
    void statefulServiceSingleton() {
        ApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);

        StatefulService statefulService1 = ac.getBean("statefulService", StatefulService.class);
        StatefulService statefulService2 = ac.getBean("statefulService", StatefulService.class);

        //ThreadA: A사용자 10000원 주문
        statefulService1.order("userA", 10000);
        //ThreadB: B사용자 20000원 주문
        statefulService2.order("userB", 20000);
        //ThreadA: A사용자 주문 금액 조회
        int price = statefulService1.getPrice();

        //ThreadA: A사용자는 10000원을 기대했지만, 기대와 다르게 20000원 출력
        System.out.println("price = " + price);
        Assertions.assertThat(statefulService1.getPrice()).isEqualTo(20000);
    }

    static class TestConfig {
        @Bean
        public StatefulService statefulService() {
            return new StatefulService();
        }
    }

}
```

## @Configuration

스프링이 CGLIB라는 바이트코드 조작 라이브러리를 사용해서 AppConfig 클래스를 상속받은 임의의 다른 클래스를 만들고, 그 다른 클래스를 스프링 빈으로 등록

![c](https://user-images.githubusercontent.com/63000763/95010845-93713480-0667-11eb-98d9-abbf87929d1b.PNG)

그 임의의 다른 클래스가 바로 싱글톤이 보장되도록 해준다. 아마도 다음과 같이 바이트 코드를 조작해서 작성되어 있을 것이다.(실제로는 CGLIB의 내부 기술을 사용하는데 매우 복잡하다.)

- @Bean이 붙은 메서드마다 이미 스프링 빈이 존재하면 존재하는 빈을 반환하고, 스프링 빈이 없으면 생성해서 스프링 빈으로 등록하고 반환하는 코드가 동적으로 만들어진다.
- 덕분에 싱글톤이 보장되는 것이다.

> 참고 AppConfig@CGLIB는 AppConfig의 자식 타입이므로, AppConfig 타입으로 조회 할 수 있다.

### @Configuration 을 적용하지 않고, @Bean 만 적용하면 어떻게 될까?
- @Bean만 사용해도 스프링 빈으로 등록되지만, 싱글톤을 보장하지 않는다.
    - memberRepository() 처럼 의존관계 주입이 필요해서 메서드를 직접 호출할 때 싱글톤을 보장하지 않는다.




